### PR TITLE
Implement demo user functionality to the Signup / Login pages #18

### DIFF
--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -19,7 +19,7 @@ function App(): JSX.Element {
           <AuthProvider>
             <SocketProvider>
               <Switch>
-                <Route exact path="/signin" component={Login} />
+                <Route exact path="/login" component={Login} />
                 <Route exact path="/signup" component={Signup} />
                 <Route exact path={'/'} component={Home} />
                 <PrivateRoute component={Booking} path={'/booking'} />

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -19,12 +19,10 @@ function App(): JSX.Element {
           <AuthProvider>
             <SocketProvider>
               <Switch>
-                <Route exact path="/login" component={Login} />
+                <Route exact path="/signin" component={Login} />
                 <Route exact path="/signup" component={Signup} />
                 <Route exact path={'/'} component={Home} />
-
                 <PrivateRoute component={Booking} path={'/booking'} />
-
                 <PrivateRoute component={Dashboard} path="/dashboard" />
               </Switch>
             </SocketProvider>

--- a/client/src/App.tsx
+++ b/client/src/App.tsx
@@ -1,14 +1,15 @@
 import { MuiThemeProvider } from '@material-ui/core';
-import { theme } from './themes/theme';
-import { BrowserRouter, Route, Redirect, Switch } from 'react-router-dom';
+import { BrowserRouter, Route, Switch } from 'react-router-dom';
+import './App.css';
+import { AuthProvider, PrivateRoute } from './context/useAuthContext';
+import { SnackBarProvider } from './context/useSnackbarContext';
+import { SocketProvider } from './context/useSocketContext';
+import Booking from './pages/Booking/Booking';
+import Dashboard from './pages/Dashboard/Dashboard';
+import Home from './pages/Home/Home';
 import Login from './pages/Login/Login';
 import Signup from './pages/SignUp/SignUp';
-import Dashboard from './pages/Dashboard/Dashboard';
-import { AuthProvider } from './context/useAuthContext';
-import { SocketProvider } from './context/useSocketContext';
-import { SnackBarProvider } from './context/useSnackbarContext';
-
-import './App.css';
+import { theme } from './themes/theme';
 
 function App(): JSX.Element {
   return (
@@ -20,12 +21,11 @@ function App(): JSX.Element {
               <Switch>
                 <Route exact path="/login" component={Login} />
                 <Route exact path="/signup" component={Signup} />
-                <Route exact path="/dashboard">
-                  <Dashboard />
-                </Route>
-                <Route path="*">
-                  <Redirect to="/login" />
-                </Route>
+                <Route exact path={'/'} component={Home} />
+
+                <PrivateRoute component={Booking} path={'/booking'} />
+
+                <PrivateRoute component={Dashboard} path="/dashboard" />
               </Switch>
             </SocketProvider>
           </AuthProvider>

--- a/client/src/components/Button/useStyles.ts
+++ b/client/src/components/Button/useStyles.ts
@@ -26,7 +26,13 @@ const useStyles = makeStyles((theme) => ({
       backgroundColor: 'transparent',
       color: '#f04040',
     },
-
+    '&.findMyDog': {
+      textTransform: 'uppercase',
+      width: '38%',
+      [theme.breakpoints.down('sm')]: {
+        width: '50%',
+      },
+    },
     '&.mySitters': {
       padding: theme.spacing(1, 4, 1, 4),
       backgroundColor: 'transparent',
@@ -73,7 +79,7 @@ const useStyles = makeStyles((theme) => ({
         color: theme.palette.common.white,
       },
       [theme.breakpoints.down('sm')]: {
-        color: '#f04040',
+        color: '#f04040 !important',
       },
     },
     '&.signup': {

--- a/client/src/components/Button/useStyles.ts
+++ b/client/src/components/Button/useStyles.ts
@@ -6,7 +6,6 @@ const useStyles = makeStyles((theme) => ({
     right: -theme.spacing(1),
     backgroundColor: theme.palette.error.main,
     display: 'none',
-
     '&.active': {
       backgroundColor: theme.palette.success.main,
       display: 'block',
@@ -15,16 +14,17 @@ const useStyles = makeStyles((theme) => ({
   button: {
     textDecoration: 'none',
     margin: 5,
-
     fontSize: 12,
     fontWeight: 600,
     color: theme.palette.common.white,
-    backgroundColor: '#f04040',
-    border: '1px solid #f04040',
+    backgroundColor: theme.palette.primary.main,
+    border: 1,
+    borderStyle: 'solid',
+    borderColor: theme.palette.primary.main,
     padding: theme.spacing(2, 4, 2, 4),
     '&:hover': {
       backgroundColor: 'transparent',
-      color: '#f04040',
+      color: theme.palette.primary.main,
     },
     '&.findMyDog': {
       textTransform: 'uppercase',
@@ -37,12 +37,11 @@ const useStyles = makeStyles((theme) => ({
       padding: theme.spacing(1, 4, 1, 4),
       backgroundColor: 'transparent',
       border: 'none',
-      color: '#f04040',
+      color: theme.palette.primary.main,
       [theme.breakpoints.down('sm')]: {
         padding: theme.spacing(1),
       },
     },
-
     '&.messages': {
       padding: theme.spacing(1, 4, 1, 4),
       backgroundColor: 'transparent',
@@ -52,44 +51,49 @@ const useStyles = makeStyles((theme) => ({
         padding: theme.spacing(1),
       },
     },
-
     '&.sitter': {
-      textTransform: 'uppercase',
       padding: theme.spacing(1, 4, 1, 4),
+      textTransform: 'uppercase',
       backgroundColor: 'transparent',
       border: 'none',
       textDecorationLine: 'underline',
       textDecorationStyle: 'solid',
       textDecorationColor: theme.palette.common.black,
       color: theme.palette.common.black,
+      '&.home': { textDecorationColor: theme.palette.common.white, color: theme.palette.common.white },
       [theme.breakpoints.down('sm')]: {
         padding: theme.spacing(1),
       },
     },
     '&.login': {
-      textTransform: 'uppercase',
       padding: theme.spacing(1, 4, 1, 4),
-      color: '#f04040',
+      textTransform: 'uppercase',
+      color: theme.palette.primary.main,
       fontSize: 12,
       fontWeight: 600,
       backgroundColor: 'transparent',
-      border: '1px solid #f04040',
+      border: 1,
+      borderStyle: 'solid',
+      borderColor: theme.palette.primary.main,
+      '&.home': { color: 'white', border: '1px solid #dfaf7a' },
       '&:hover': {
-        backgroundColor: '#f04040',
+        backgroundColor: theme.palette.primary.main,
         color: theme.palette.common.white,
       },
       [theme.breakpoints.down('sm')]: {
-        color: '#f04040 !important',
+        color: `${theme.palette.primary.main}!important`,
       },
     },
     '&.signup': {
-      textTransform: 'uppercase',
       padding: theme.spacing(1, 4, 1, 4),
+      textTransform: 'uppercase',
     },
     '&.checkout': {
-      textTransform: 'uppercase',
       padding: theme.spacing(0.1, 0.5, 0.1, 0.5),
-      border: '1px solid #f04040',
+      textTransform: 'uppercase',
+      border: 1,
+      borderStyle: 'solid',
+      borderColor: theme.palette.primary.main,
     },
   },
 }));

--- a/client/src/components/Button/useStyles.ts
+++ b/client/src/components/Button/useStyles.ts
@@ -65,7 +65,7 @@ const useStyles = makeStyles((theme) => ({
         padding: theme.spacing(1),
       },
     },
-    '&.login': {
+    '&.login, &.notFoundHome': {
       padding: theme.spacing(1, 4, 1, 4),
       textTransform: 'uppercase',
       color: theme.palette.primary.main,
@@ -84,7 +84,7 @@ const useStyles = makeStyles((theme) => ({
         color: `${theme.palette.primary.main}!important`,
       },
     },
-    '&.signup': {
+    '&.signup, &.report': {
       padding: theme.spacing(1, 4, 1, 4),
       textTransform: 'uppercase',
     },

--- a/client/src/components/DemoUser/DemoUser.tsx
+++ b/client/src/components/DemoUser/DemoUser.tsx
@@ -1,0 +1,43 @@
+import { Box, Button, Typography } from '@material-ui/core';
+import { useAuth } from '../../context/useAuthContext';
+import { useSnackBar } from '../../context/useSnackbarContext';
+import login from '../../helpers/APICalls/login';
+import useDemoCredentials from './useDemoCredentials';
+import useStyles from './useStyles';
+
+const DemoUser = (): JSX.Element => {
+  const { linkDemo, captionDemo } = useStyles();
+  const { updateLoginContext } = useAuth();
+  const { updateSnackBarMessage } = useSnackBar();
+  const { ownerDemo, sitterDemo } = useDemoCredentials();
+
+  const handleDemoSubmit = ({ email, password }: { email: string; password: string }) => {
+    login(email, password).then((data) => {
+      if (data.error) {
+        updateSnackBarMessage(data.error.message);
+      } else if (data.success) {
+        updateLoginContext(data.success);
+      } else {
+        updateSnackBarMessage('An unexpected error occurred. Please try again !');
+      }
+    });
+  };
+
+  return (
+    <>
+      <Box textAlign="center" borderTop={'1px dotted red'} pt={1} mt={2} borderRadius={25}>
+        <Typography className={captionDemo}>
+          Sign in as a demo user &nbsp;
+          <Button className={linkDemo} onClick={() => handleDemoSubmit(ownerDemo)}>
+            Owner
+          </Button>
+          <Button className={linkDemo} onClick={() => handleDemoSubmit(sitterDemo)}>
+            Sitter
+          </Button>
+        </Typography>
+      </Box>
+    </>
+  );
+};
+
+export default DemoUser;

--- a/client/src/components/DemoUser/useDemoCredentials.ts
+++ b/client/src/components/DemoUser/useDemoCredentials.ts
@@ -1,0 +1,12 @@
+const useDemoCredentials = () => ({
+  ownerDemo: {
+    email: 'ownerDemo@lovingSitter.ca',
+    password: "e^Ha48'%-J);w",
+  },
+  sitterDemo: {
+    email: 'sitterDemo@lovingSitter.ca',
+    password: 'P(y-AqHt,]>Bc9>]',
+  },
+});
+
+export default useDemoCredentials;

--- a/client/src/components/DemoUser/useStyles.ts
+++ b/client/src/components/DemoUser/useStyles.ts
@@ -1,0 +1,13 @@
+import { makeStyles } from '@material-ui/core/styles';
+const useStyles = makeStyles((theme) => ({
+  captionDemo: {
+    fontWeight: 400,
+  },
+  linkDemo: {
+    textDecoration: 'none',
+    color: theme.palette.primary.main,
+    margin: theme.spacing(1),
+  },
+}));
+
+export default useStyles;

--- a/client/src/components/Input/CustomInput.ts
+++ b/client/src/components/Input/CustomInput.ts
@@ -1,0 +1,25 @@
+import { InputBase, withStyles, alpha } from '@material-ui/core';
+
+export const CustomInput = withStyles((theme) => ({
+  root: {
+    'label + &': {
+      marginTop: theme.spacing(1),
+      marginBottom: theme.spacing(2),
+    },
+  },
+  input: {
+    borderRadius: 4,
+    position: 'relative',
+    backgroundColor: theme.palette.common.white,
+    border: '1px solid #ced4da',
+    fontSize: 16,
+    width: '80%',
+    height: '100%',
+    padding: theme.spacing(2),
+    transition: theme.transitions.create(['border-color', 'box-shadow']),
+    '&:focus': {
+      boxShadow: `${alpha(theme.palette.primary.main, 0.25)} 0 0 0 0.2rem`,
+      borderColor: theme.palette.primary.main,
+    },
+  },
+}))(InputBase);

--- a/client/src/components/NavBar/AuthMenu.tsx
+++ b/client/src/components/NavBar/AuthMenu.tsx
@@ -4,8 +4,7 @@ import { CustomButton } from '../Button/CustomButton';
 const AuthMenu = (): JSX.Element => {
   return (
     <Box display="flex" justifyContent="flex-end">
-      <CustomButton linkTo={'/'} btnText={'Become a sitter'} style={'sitter'} />
-      <CustomButton linkTo={'/signin'} btnText={'Login'} style={'login'} />
+      <CustomButton linkTo={'/login'} btnText={'Login'} style={'login'} />
       <CustomButton linkTo={'/signup'} btnText={'Signup'} style={'signup'} />
     </Box>
   );

--- a/client/src/components/NavBar/AuthMenu.tsx
+++ b/client/src/components/NavBar/AuthMenu.tsx
@@ -6,7 +6,6 @@ const AuthMenu = (): JSX.Element => {
   const { buttonContainer } = useStyles();
   return (
     <Box className={buttonContainer}>
-      <CustomButton linkTo={'/'} btnText={'Become a sitter'} style={'sitter'} />
       <CustomButton linkTo={'/signin'} btnText={'Login'} style={'login'} />
       <CustomButton linkTo={'/signup'} btnText={'Signup'} style={'signup'} />
     </Box>

--- a/client/src/components/NavBar/useStyles.ts
+++ b/client/src/components/NavBar/useStyles.ts
@@ -13,11 +13,13 @@ const useStyles = makeStyles((theme) => ({
     alignItems: 'center',
     cursor: 'pointer',
   },
-
   leftLogoText: {
     marginLeft: theme.spacing(1),
     fontSize: 22,
     fontWeight: 700,
+    [theme.breakpoints.down('xs')]: {
+      display: 'none',
+    },
   },
   link: {
     textDecoration: 'none',
@@ -30,69 +32,6 @@ const useStyles = makeStyles((theme) => ({
 
     '&.active': {
       backgroundColor: theme.palette.success.main,
-    },
-  },
-  button: {
-    fontSize: 12,
-    fontWeight: 600,
-    color: theme.palette.common.white,
-    backgroundColor: '#f04040',
-    border: '1px solid #f04040',
-    padding: theme.spacing(2, 4, 2, 4),
-    '&:hover': {
-      backgroundColor: 'transparent',
-      color: '#f04040',
-    },
-
-    '&.mySitters': {
-      padding: theme.spacing(1, 4, 1, 4),
-      backgroundColor: 'transparent',
-      border: 'none',
-      color: '#f04040',
-      [theme.breakpoints.down('sm')]: {
-        padding: theme.spacing(1),
-      },
-    },
-
-    '&.messages': {
-      padding: theme.spacing(1, 4, 1, 4),
-      backgroundColor: 'transparent',
-      border: 'none',
-      color: theme.palette.common.black,
-      [theme.breakpoints.down('sm')]: {
-        padding: theme.spacing(1),
-      },
-    },
-
-    '&.sitter': {
-      padding: theme.spacing(1, 4, 1, 4),
-      backgroundColor: 'transparent',
-      border: 'none',
-      textDecorationLine: 'underline',
-      textDecorationStyle: 'solid',
-      textDecorationColor: theme.palette.common.black,
-      color: theme.palette.common.black,
-      [theme.breakpoints.down('sm')]: {
-        padding: theme.spacing(1),
-      },
-    },
-    '&.login': {
-      padding: theme.spacing(1, 4, 1, 4),
-      color: '#f04040',
-      fontSize: 12,
-      fontWeight: 600,
-      backgroundColor: 'transparent',
-      border: '1px solid #f04040',
-      '&:hover': {
-        backgroundColor: '#f04040',
-        color: theme.palette.common.white,
-      },
-      [theme.breakpoints.down('sm')]: {
-        color: '#f04040',
-      },
-    },
-    '&.signup': {
-      padding: theme.spacing(1, 4, 1, 4),
     },
   },
   buttonContainer: {

--- a/client/src/pages/Home/Home.tsx
+++ b/client/src/pages/Home/Home.tsx
@@ -4,6 +4,8 @@ import useStyles from './useStyles';
 import clsx from 'clsx';
 import { CustomButton } from '../../components/Button/CustomButton';
 import { CustomInput } from '../../components/Input/CustomInput';
+import { styled } from '@material-ui/core/styles';
+import { spacing } from '@material-ui/system';
 
 const FormElement = ({ children }: { children: JSX.Element[] | JSX.Element }): JSX.Element => {
   return (
@@ -13,14 +15,15 @@ const FormElement = ({ children }: { children: JSX.Element[] | JSX.Element }): J
   );
 };
 
+const HomeGrid = styled(Grid)(spacing);
+
 const Home = (): JSX.Element => {
-  const theme = useTheme();
   const { root, leftLogoContainer, leftLogoText, leftBodyContainer, slogan, label, dateInOff, right, background } =
     useStyles();
   return (
     <>
-      <Grid container className={root}>
-        <Grid item xs={12} md={6} style={{ padding: theme.spacing(4) }}>
+      <HomeGrid container className={root}>
+        <HomeGrid item xs={12} md={6} p={4}>
           <Paper variant="outlined" className={leftLogoContainer}>
             <img src="/assets/logo.png" alt={'Marketplace for Dog Sitters, Dog Owners'} />
             <Typography variant="h4" className={leftLogoText}>
@@ -52,31 +55,16 @@ const Home = (): JSX.Element => {
               </FormElement>
             </form>
           </Container>
-        </Grid>
-        <Grid item xs={12} md={6} className={right}>
+        </HomeGrid>
+        <HomeGrid item xs={12} md={6} p={3} className={right}>
           <img src="/assets/bg.jpg" alt={'Marketplace for Dog Sitters, Dog Owners'} className={background} />
           <Box display="flex" justifyContent="flex-end">
-            <CustomButton
-              linkTo={'/'}
-              btnText={'Become a sitter'}
-              style={'sitter'}
-              cssStyle={{
-                color: 'white',
-                textDecorationLine: 'underline',
-                textDecorationStyle: 'solid',
-                textDecorationColor: 'white',
-              }}
-            />
-            <CustomButton
-              linkTo={'/signin'}
-              btnText={'Login'}
-              style={'login'}
-              cssStyle={{ color: 'white', border: '1px solid #dfaf7a' }}
-            />
+            <CustomButton linkTo={'/'} btnText={'Become a sitter'} style={clsx('sitter', 'home')} />
+            <CustomButton linkTo={'/signin'} btnText={'Login'} style={clsx('login', 'home')} />
             <CustomButton linkTo={'/signup'} btnText={'Signup'} style={'signup'} />
           </Box>
-        </Grid>
-      </Grid>
+        </HomeGrid>
+      </HomeGrid>
     </>
   );
 };

--- a/client/src/pages/Home/Home.tsx
+++ b/client/src/pages/Home/Home.tsx
@@ -1,0 +1,84 @@
+import { Box, Container, Grid, InputLabel, Paper, TextField, Typography } from '@material-ui/core';
+import { useTheme } from '@material-ui/core/styles';
+import useStyles from './useStyles';
+import clsx from 'clsx';
+import { CustomButton } from '../../components/Button/CustomButton';
+import { CustomInput } from '../../components/Input/CustomInput';
+
+const FormElement = ({ children }: { children: JSX.Element[] | JSX.Element }): JSX.Element => {
+  return (
+    <Box display="flex" flexDirection="column" marginBottom={3}>
+      {children}
+    </Box>
+  );
+};
+
+const Home = (): JSX.Element => {
+  const theme = useTheme();
+  const { root, leftLogoContainer, leftLogoText, leftBodyContainer, slogan, label, dateInOff, right, background } =
+    useStyles();
+  return (
+    <>
+      <Grid container className={root}>
+        <Grid item xs={12} md={6} style={{ padding: theme.spacing(4) }}>
+          <Paper variant="outlined" className={leftLogoContainer}>
+            <img src="/assets/logo.png" alt={'Marketplace for Dog Sitters, Dog Owners'} />
+            <Typography variant="h4" className={leftLogoText}>
+              LovingSitter.
+            </Typography>
+          </Paper>
+          <Container className={leftBodyContainer}>
+            <Typography variant="h1" className={slogan}>
+              Find the care your dog deserves
+            </Typography>
+            <form action="/action" method="get">
+              <FormElement>
+                <InputLabel htmlFor="where" className={label}>
+                  Where
+                </InputLabel>
+                <CustomInput placeholder="Anywhere" id="where" />
+              </FormElement>
+              <FormElement>
+                <InputLabel htmlFor="date" className={label}>
+                  Drop In / Drop Off
+                </InputLabel>
+                <Box width={'100%'} display="flex">
+                  <TextField id="dateIn" type="date" defaultValue="2022-01-01" className={clsx(dateInOff, 'left')} />
+                  <TextField id="dateOff" type="date" defaultValue="2022-01-10" className={clsx(dateInOff, 'right')} />
+                </Box>
+              </FormElement>
+              <FormElement>
+                <CustomButton linkTo={'/'} btnText={'Find My Dog Sitter'} style={'findMyDog'} />
+              </FormElement>
+            </form>
+          </Container>
+        </Grid>
+        <Grid item xs={12} md={6} className={right}>
+          <img src="/assets/bg.jpg" alt={'Marketplace for Dog Sitters, Dog Owners'} className={background} />
+          <Box display="flex" justifyContent="flex-end">
+            <CustomButton
+              linkTo={'/'}
+              btnText={'Become a sitter'}
+              style={'sitter'}
+              cssStyle={{
+                color: 'white',
+                textDecorationLine: 'underline',
+                textDecorationStyle: 'solid',
+                textDecorationColor: 'white',
+              }}
+            />
+            <CustomButton
+              linkTo={'/signin'}
+              btnText={'Login'}
+              style={'login'}
+              cssStyle={{ color: 'white', border: '1px solid #dfaf7a' }}
+            />
+            <CustomButton linkTo={'/signup'} btnText={'Signup'} style={'signup'} />
+          </Box>
+        </Grid>
+      </Grid>
+    </>
+  );
+};
+
+export default Home;

--- a/client/src/pages/Home/useStyles.ts
+++ b/client/src/pages/Home/useStyles.ts
@@ -6,7 +6,6 @@ const useStyles = makeStyles((theme) => ({
     minHeight: '100vh',
   },
   right: {
-    padding: theme.spacing(3),
     position: 'relative',
   },
   background: {

--- a/client/src/pages/Home/useStyles.ts
+++ b/client/src/pages/Home/useStyles.ts
@@ -1,0 +1,83 @@
+import { makeStyles } from '@material-ui/core/styles';
+import { alpha } from '@material-ui/core';
+
+const useStyles = makeStyles((theme) => ({
+  root: {
+    minHeight: '100vh',
+  },
+  right: {
+    padding: theme.spacing(3),
+    position: 'relative',
+  },
+  background: {
+    position: 'absolute',
+    top: 0,
+    right: 0,
+    objectFit: 'cover',
+    zIndex: -1,
+    width: '100%',
+    height: '100%',
+    [theme.breakpoints.down('sm')]: {
+      display: 'none',
+    },
+  },
+  leftLogoContainer: {
+    border: 'none',
+    backgroundColor: 'transparent',
+    display: 'flex',
+    alignItems: 'center',
+    cursor: 'pointer',
+  },
+  leftLogoText: {
+    marginLeft: theme.spacing(1),
+    fontSize: 26,
+    fontWeight: 900,
+  },
+  dateInOff: {
+    marginTop: theme.spacing(1),
+    marginBottom: theme.spacing(2),
+    borderRadius: 4,
+    position: 'relative',
+    backgroundColor: theme.palette.common.white,
+    border: '1px solid #ced4da',
+    width: '40%',
+    height: '100%',
+    padding: theme.spacing(1),
+    paddingBottom: '14px',
+    transition: theme.transitions.create(['border-color', 'box-shadow']),
+    '&:focus': {
+      boxShadow: `${alpha(theme.palette.primary.main, 0.25)} 0 0 0 0.2rem`,
+      borderColor: theme.palette.primary.main,
+    },
+    '&.left': {
+      borderTopRightRadius: 0,
+      borderBottomRightRadius: 0,
+    },
+    '&.right': {
+      borderTopLeftRadius: 0,
+      borderBottomLeftRadius: 0,
+    },
+  },
+  leftBodyContainer: {
+    padding: theme.spacing(3, 8, 2, 8),
+    [theme.breakpoints.down('sm')]: {
+      padding: theme.spacing(1, 2, 1, 2),
+    },
+  },
+  slogan: {
+    marginTop: theme.spacing(6),
+    marginBottom: theme.spacing(6),
+    fontSize: 50,
+    fontWeight: 600,
+    [theme.breakpoints.down('sm')]: {
+      fontSize: 35,
+    },
+  },
+  label: {
+    fontWeight: 800,
+    color: theme.palette.common.black,
+    textTransform: 'uppercase',
+  },
+}));
+
+export default useStyles;

--- a/client/src/pages/Login/Login.tsx
+++ b/client/src/pages/Login/Login.tsx
@@ -1,20 +1,28 @@
-import CssBaseline from '@material-ui/core/CssBaseline';
-import Paper from '@material-ui/core/Paper';
+import { CircularProgress } from '@material-ui/core';
 import Box from '@material-ui/core/Box';
 import Grid from '@material-ui/core/Grid';
-import { FormikHelpers } from 'formik';
+import Paper from '@material-ui/core/Paper';
 import Typography from '@material-ui/core/Typography';
-import useStyles from './useStyles';
-import login from '../../helpers/APICalls/login';
-import LoginForm from './LoginForm/LoginForm';
-import AuthHeader from '../../components/AuthHeader/AuthHeader';
+import { FormikHelpers } from 'formik';
+import { useHistory } from 'react-router-dom';
+import NavBar from '../../components/NavBar/NavBar';
 import { useAuth } from '../../context/useAuthContext';
 import { useSnackBar } from '../../context/useSnackbarContext';
+import login from '../../helpers/APICalls/login';
+import LoginForm from './LoginForm/LoginForm';
+import useStyles from './useStyles';
 
 export default function Login(): JSX.Element {
   const classes = useStyles();
-  const { updateLoginContext } = useAuth();
+  const { updateLoginContext, loggedInUser } = useAuth();
   const { updateSnackBarMessage } = useSnackBar();
+
+  const history = useHistory();
+
+  if (loggedInUser) {
+    history.push('/booking');
+    return <CircularProgress />;
+  }
 
   const handleSubmit = (
     { email, password }: { email: string; password: string },
@@ -27,34 +35,37 @@ export default function Login(): JSX.Element {
       } else if (data.success) {
         updateLoginContext(data.success);
       } else {
-        // should not get here from backend but this catch is for an unknown issue
-        console.error({ data });
-
         setSubmitting(false);
-        updateSnackBarMessage('An unexpected error occurred. Please try again');
+        updateSnackBarMessage('An unexpected error occurred. Please try again !');
       }
     });
   };
 
   return (
-    <Grid container component="main" className={classes.root}>
-      <CssBaseline />
-      <Grid item xs={12} sm={8} md={7} elevation={6} component={Paper} square>
-        <Box className={classes.authWrapper}>
-          <AuthHeader linkTo="/signup" asideText="Don't have an account?" btnText="Create account" />
-          <Box width="100%" maxWidth={450} p={3} alignSelf="center">
-            <Grid container>
-              <Grid item xs>
-                <Typography className={classes.welcome} component="h1" variant="h5">
-                  Welcome back!
+    <>
+      <NavBar />
+      <Grid container component="main" className={classes.root}>
+        <Grid item xs={6} sm={8} md={4} elevation={0} component={Paper} square>
+          <Box
+            display={'flex'}
+            alignItems={'flex-start'}
+            justifyContent={'space-between'}
+            flexDirection={'column'}
+            minHeight={'100vh'}
+            paddingTop={3}
+            width={'80%'}
+          >
+            <Box width={'100%'} maxWidth={450} p={3} alignSelf={'center'}>
+              <Box textAlign="center">
+                <Typography variant="h5" className={classes.welcome}>
+                  Sign in
                 </Typography>
-              </Grid>
-            </Grid>
-            <LoginForm handleSubmit={handleSubmit} />
+              </Box>
+              <LoginForm handleSubmit={handleSubmit} />
+            </Box>
           </Box>
-          <Box p={1} alignSelf="center" />
-        </Box>
+        </Grid>
       </Grid>
-    </Grid>
+    </>
   );
 }

--- a/client/src/pages/Login/LoginForm/LoginForm.tsx
+++ b/client/src/pages/Login/LoginForm/LoginForm.tsx
@@ -5,7 +5,8 @@ import { Formik, FormikHelpers } from 'formik';
 import * as Yup from 'yup';
 import Typography from '@material-ui/core/Typography';
 import useStyles from './useStyles';
-import { CircularProgress } from '@material-ui/core';
+import { CircularProgress, InputLabel } from '@material-ui/core';
+import { Link } from 'react-router-dom';
 
 interface Props {
   handleSubmit: (
@@ -27,7 +28,7 @@ interface Props {
 }
 
 export default function Login({ handleSubmit }: Props): JSX.Element {
-  const classes = useStyles();
+  const { form, caption, link, label, inputs, submit, circularProgress } = useStyles();
 
   return (
     <Formik
@@ -45,51 +46,65 @@ export default function Login({ handleSubmit }: Props): JSX.Element {
       onSubmit={handleSubmit}
     >
       {({ handleSubmit, handleChange, values, touched, errors, isSubmitting }) => (
-        <form onSubmit={handleSubmit} className={classes.form} noValidate>
+        <form onSubmit={handleSubmit} className={form} noValidate>
+          <InputLabel htmlFor="email" className={label}>
+            Email
+          </InputLabel>
           <TextField
             id="email"
-            label={<Typography className={classes.label}>E-mail address</Typography>}
             fullWidth
             margin="normal"
             InputLabelProps={{
               shrink: true,
             }}
             InputProps={{
-              classes: { input: classes.inputs },
+              classes: { input: inputs },
+              disableUnderline: true,
             }}
             name="email"
             autoComplete="email"
+            placeholder="Email"
             autoFocus
             helperText={touched.email ? errors.email : ''}
             error={touched.email && Boolean(errors.email)}
             value={values.email}
             onChange={handleChange}
           />
+          <InputLabel htmlFor="password" className={label}>
+            Password
+          </InputLabel>
           <TextField
             id="password"
-            label={<Typography className={classes.label}>Password</Typography>}
             fullWidth
             margin="normal"
             InputLabelProps={{
               shrink: true,
             }}
             InputProps={{
-              classes: { input: classes.inputs },
-              endAdornment: <Typography className={classes.forgot}>Forgot?</Typography>,
+              classes: { input: inputs },
+              disableUnderline: true,
             }}
             type="password"
             autoComplete="current-password"
+            placeholder="Password"
             helperText={touched.password ? errors.password : ''}
             error={touched.password && Boolean(errors.password)}
             value={values.password}
             onChange={handleChange}
           />
           <Box textAlign="center">
-            <Button type="submit" size="large" variant="contained" color="primary" className={classes.submit}>
-              {isSubmitting ? <CircularProgress style={{ color: 'white' }} /> : 'Login'}
+            <Button type="submit" size="large" variant="contained" color="primary" className={submit}>
+              {isSubmitting ? <CircularProgress className={circularProgress} /> : 'Login'}
             </Button>
           </Box>
-          <div style={{ height: 95 }} />
+          <Box textAlign="center">
+            <Typography className={caption}>
+              Don&apos;t have an account? &nbsp;
+              <Link className={link} to="/signup">
+                Signup
+              </Link>
+            </Typography>
+          </Box>
         </form>
       )}
     </Formik>

--- a/client/src/pages/Login/LoginForm/LoginForm.tsx
+++ b/client/src/pages/Login/LoginForm/LoginForm.tsx
@@ -7,6 +7,7 @@ import Typography from '@material-ui/core/Typography';
 import useStyles from './useStyles';
 import { CircularProgress, InputLabel } from '@material-ui/core';
 import { Link } from 'react-router-dom';
+import DemoUser from '../../../components/DemoUser/DemoUser';
 
 interface Props {
   handleSubmit: (
@@ -105,6 +106,7 @@ export default function Login({ handleSubmit }: Props): JSX.Element {
               </Link>
             </Typography>
           </Box>
+          <DemoUser />
         </form>
       )}
     </Formik>

--- a/client/src/pages/Login/LoginForm/useStyles.ts
+++ b/client/src/pages/Login/LoginForm/useStyles.ts
@@ -1,34 +1,56 @@
+import { alpha } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
-
 const useStyles = makeStyles((theme) => ({
   form: {
-    width: '100%', // Fix IE 11 issue.
+    width: '100%',
     marginTop: theme.spacing(1),
+    '& .MuiFormControl-root': {
+      marginTop: theme.spacing(1),
+    },
+  },
+  caption: {
+    fontWeight: 'bold',
+  },
+  link: {
+    textDecoration: 'none',
+    color: theme.palette.primary.main,
   },
   label: {
-    fontSize: 19,
-    color: 'rgb(0,0,0,0.4)',
-    paddingLeft: '5px',
+    fontWeight: 800,
+    fontSize: 12,
+    color: theme.palette.common.black,
+    textTransform: 'uppercase',
+    marginTop: theme.spacing(1),
   },
   inputs: {
-    marginTop: '.8rem',
-    height: '2rem',
-    padding: '5px',
-  },
-  forgot: {
-    paddingRight: 10,
-    color: '#3a8dff',
+    borderRadius: 4,
+    position: 'relative',
+    backgroundColor: theme.palette.common.white,
+    border: '1px solid #ced4da',
+    fontSize: 16,
+    //width: '80%',
+    height: '100%',
+    padding: theme.spacing(2),
+    marginTop: 0,
+    transition: theme.transitions.create(['border-color', 'box-shadow']),
+    '&:focus': {
+      boxShadow: `${alpha(theme.palette.primary.main, 0.25)} 0 0 0 0.2rem`,
+      borderColor: theme.palette.primary.main,
+    },
   },
   submit: {
-    margin: theme.spacing(3, 2, 2),
-    padding: 10,
+    textTransform: 'uppercase',
+    margin: theme.spacing(6, 2, 2),
+    padding: theme.spacing(1),
     width: 160,
     height: 56,
     borderRadius: theme.shape.borderRadius,
-    marginTop: 49,
-    fontSize: 16,
-    backgroundColor: '#3a8dff',
-    fontWeight: 'bold',
+    backgroundColor: theme.palette.primary.main,
+    fontSize: 12,
+    fontWeight: 600,
+  },
+  circularProgress: {
+    color: theme.palette.common.white,
   },
 }));
 

--- a/client/src/pages/Login/LoginForm/useStyles.ts
+++ b/client/src/pages/Login/LoginForm/useStyles.ts
@@ -28,7 +28,6 @@ const useStyles = makeStyles((theme) => ({
     backgroundColor: theme.palette.common.white,
     border: '1px solid #ced4da',
     fontSize: 16,
-    //width: '80%',
     height: '100%',
     padding: theme.spacing(2),
     marginTop: 0,
@@ -51,6 +50,12 @@ const useStyles = makeStyles((theme) => ({
   },
   circularProgress: {
     color: theme.palette.common.white,
+  },
+
+  linkDemo: {
+    textDecoration: 'none',
+    color: theme.palette.primary.main,
+    margin: theme.spacing(1),
   },
 }));
 

--- a/client/src/pages/Login/useStyles.ts
+++ b/client/src/pages/Login/useStyles.ts
@@ -1,26 +1,22 @@
 import { makeStyles } from '@material-ui/core/styles';
 
-const useStyles = makeStyles(() => ({
+const useStyles = makeStyles((theme) => ({
   root: {
     minHeight: '100vh',
     '& .MuiInput-underline:before': {
       borderBottom: '1.2px solid rgba(0, 0, 0, 0.2)',
     },
-  },
-  authWrapper: {
-    display: 'flex',
-    alignItems: 'flex-start',
-    justifyContent: 'space-between',
-    flexDirection: 'column',
-    minHeight: '100vh',
-    paddingTop: 23,
+    alignContent: 'center',
+    justifyContent: 'center',
+    paddingTop: theme.spacing(10),
   },
   welcome: {
     fontSize: 26,
     paddingBottom: 20,
-    color: '#000000',
+    color: theme.palette.common.black,
     fontWeight: 700,
-    fontFamily: "'Open Sans'",
+    textAlign: 'center',
+    width: '95%',
   },
 }));
 

--- a/client/src/pages/SignUp/SignUp.tsx
+++ b/client/src/pages/SignUp/SignUp.tsx
@@ -1,26 +1,40 @@
-import CssBaseline from '@material-ui/core/CssBaseline';
-import Paper from '@material-ui/core/Paper';
+import { CircularProgress } from '@material-ui/core';
 import Box from '@material-ui/core/Box';
 import Grid from '@material-ui/core/Grid';
-import { FormikHelpers } from 'formik';
+import Paper from '@material-ui/core/Paper';
 import Typography from '@material-ui/core/Typography';
-import useStyles from './useStyles';
-import register from '../../helpers/APICalls/register';
-import SignUpForm from './SignUpForm/SignUpForm';
-import AuthHeader from '../../components/AuthHeader/AuthHeader';
+import { FormikHelpers } from 'formik';
+import { useHistory } from 'react-router';
+import NavBar from '../../components/NavBar/NavBar';
 import { useAuth } from '../../context/useAuthContext';
 import { useSnackBar } from '../../context/useSnackbarContext';
+import register from '../../helpers/APICalls/register';
+import SignUpForm from './SignUpForm/SignUpForm';
+import useStyles from './useStyles';
 
 export default function Register(): JSX.Element {
   const classes = useStyles();
-  const { updateLoginContext } = useAuth();
+  const { updateLoginContext, loggedInUser } = useAuth();
   const { updateSnackBarMessage } = useSnackBar();
+  const history = useHistory();
+
+  if (loggedInUser) {
+    history.push('/booking');
+    return <CircularProgress />;
+  }
 
   const handleSubmit = (
-    { username, email, password }: { email: string; password: string; username: string },
-    { setSubmitting }: FormikHelpers<{ email: string; password: string; username: string }>,
+    {
+      username,
+      email,
+      password,
+      role,
+    }: { email: string; password: string; username: string; confirmPassword: string; role: string },
+    {
+      setSubmitting,
+    }: FormikHelpers<{ email: string; password: string; username: string; confirmPassword: string; role: string }>,
   ) => {
-    register(username, email, password).then((data) => {
+    register(username, email, password, role).then((data) => {
       if (data.error) {
         console.error({ error: data.error.message });
         setSubmitting(false);
@@ -28,34 +42,36 @@ export default function Register(): JSX.Element {
       } else if (data.success) {
         updateLoginContext(data.success);
       } else {
-        // should not get here from backend but this catch is for an unknown issue
-        console.error({ data });
-
         setSubmitting(false);
-        updateSnackBarMessage('An unexpected error occurred. Please try again');
+        updateSnackBarMessage('An unexpected error occurred. Please try again !');
       }
     });
   };
 
   return (
-    <Grid container component="main" className={classes.root}>
-      <CssBaseline />
-      <Grid item xs={12} sm={8} md={7} elevation={6} component={Paper} square>
-        <Box className={classes.authWrapper}>
-          <AuthHeader linkTo="/login" asideText="Already have an account?" btnText="Login" />
-          <Box width="100%" maxWidth={450} p={3} alignSelf="center">
-            <Grid container>
-              <Grid item xs>
-                <Typography className={classes.welcome} component="h1" variant="h5">
-                  Create an account
+    <>
+      <NavBar />
+      <Grid container component="main" className={classes.root}>
+        <Grid item xs={6} sm={8} md={4} elevation={0} component={Paper} square>
+          <Box
+            display="flex"
+            alignItems="flex-start"
+            justifyContent="space-between"
+            flexDirection="column"
+            minHeight="100vh"
+            paddingTop={3}
+          >
+            <Box width="100%" maxWidth={450} p={3} alignSelf="center">
+              <Box textAlign="center">
+                <Typography variant="h5" className={classes.welcome}>
+                  Sign up
                 </Typography>
-              </Grid>
-            </Grid>
-            <SignUpForm handleSubmit={handleSubmit} />
+              </Box>
+              <SignUpForm handleSubmit={handleSubmit} />
+            </Box>
           </Box>
-          <Box p={1} alignSelf="center" />
-        </Box>
+        </Grid>
       </Grid>
-    </Grid>
+    </>
   );
 }

--- a/client/src/pages/SignUp/SignUpForm/SignUpForm.tsx
+++ b/client/src/pages/SignUp/SignUpForm/SignUpForm.tsx
@@ -8,6 +8,7 @@ import { useState } from 'react';
 import { Link } from 'react-router-dom';
 import * as Yup from 'yup';
 import useStyles from './useStyles';
+import DemoUser from '../../../components/DemoUser/DemoUser';
 
 interface Props {
   handleSubmit: (
@@ -187,6 +188,7 @@ const SignUpForm = ({ handleSubmit }: Props): JSX.Element => {
               </Link>
             </Typography>
           </Box>
+          <DemoUser />
         </form>
       )}
     </Formik>

--- a/client/src/pages/SignUp/SignUpForm/SignUpForm.tsx
+++ b/client/src/pages/SignUp/SignUpForm/SignUpForm.tsx
@@ -1,11 +1,13 @@
+import { ButtonGroup, CircularProgress, Grid, InputLabel } from '@material-ui/core';
+import Box from '@material-ui/core/Box';
 import Button from '@material-ui/core/Button';
 import TextField from '@material-ui/core/TextField';
-import Box from '@material-ui/core/Box';
-import { Formik, FormikHelpers } from 'formik';
-import * as Yup from 'yup';
 import Typography from '@material-ui/core/Typography';
+import { Formik, FormikHelpers } from 'formik';
+import { useState } from 'react';
+import { Link } from 'react-router-dom';
+import * as Yup from 'yup';
 import useStyles from './useStyles';
-import { CircularProgress } from '@material-ui/core';
 
 interface Props {
   handleSubmit: (
@@ -13,10 +15,14 @@ interface Props {
       username,
       email,
       password,
+      confirmPassword,
+      role,
     }: {
       email: string;
       password: string;
       username: string;
+      confirmPassword: string;
+      role: string;
     },
     {
       setStatus,
@@ -25,12 +31,20 @@ interface Props {
       email: string;
       password: string;
       username: string;
+      confirmPassword: string;
+      role: string;
     }>,
   ) => void;
 }
 
 const SignUpForm = ({ handleSubmit }: Props): JSX.Element => {
-  const classes = useStyles();
+  const { form, caption, link, label, inputs, submit, circularProgress, roleButton } = useStyles();
+  const [role, setRole] = useState(true);
+
+  const handleRoleButton = (): string => {
+    setRole(!role);
+    return role ? 'owner' : 'sitter';
+  };
 
   return (
     <Formik
@@ -38,6 +52,8 @@ const SignUpForm = ({ handleSubmit }: Props): JSX.Element => {
         email: '',
         password: '',
         username: '',
+        confirmPassword: '',
+        role: 'sitter',
       }}
       validationSchema={Yup.object().shape({
         username: Yup.string().required('Username is required').max(40, 'Username is too long'),
@@ -46,71 +62,130 @@ const SignUpForm = ({ handleSubmit }: Props): JSX.Element => {
           .required('Password is required')
           .max(100, 'Password is too long')
           .min(6, 'Password too short'),
+        confirmPassword: Yup.string().oneOf([Yup.ref('password'), null], 'Passwords must match'),
       })}
       onSubmit={handleSubmit}
     >
-      {({ handleSubmit, handleChange, values, touched, errors, isSubmitting }) => (
-        <form onSubmit={handleSubmit} className={classes.form} noValidate>
-          <TextField
-            id="username"
-            label={<Typography className={classes.label}>Username</Typography>}
-            fullWidth
-            margin="normal"
-            InputLabelProps={{
-              shrink: true,
-            }}
-            InputProps={{
-              classes: { input: classes.inputs },
-            }}
-            name="username"
-            autoComplete="username"
-            autoFocus
-            helperText={touched.username ? errors.username : ''}
-            error={touched.username && Boolean(errors.username)}
-            value={values.username}
-            onChange={handleChange}
-          />
-          <TextField
-            id="email"
-            label={<Typography className={classes.label}>E-mail address</Typography>}
-            fullWidth
-            margin="normal"
-            InputLabelProps={{
-              shrink: true,
-            }}
-            InputProps={{
-              classes: { input: classes.inputs },
-            }}
-            name="email"
-            autoComplete="email"
-            helperText={touched.email ? errors.email : ''}
-            error={touched.email && Boolean(errors.email)}
-            value={values.email}
-            onChange={handleChange}
-          />
-          <TextField
-            id="password"
-            label={<Typography className={classes.label}>Password</Typography>}
-            fullWidth
-            margin="normal"
-            InputLabelProps={{
-              shrink: true,
-            }}
-            InputProps={{
-              classes: { input: classes.inputs },
-            }}
-            type="password"
-            autoComplete="current-password"
-            helperText={touched.password ? errors.password : ''}
-            error={touched.password && Boolean(errors.password)}
-            value={values.password}
-            onChange={handleChange}
-          />
+      {({ handleSubmit, handleChange, setFieldValue, values, touched, errors, isSubmitting }) => (
+        <form onSubmit={handleSubmit} className={form} noValidate>
+          <Grid container spacing={1}>
+            <Grid item xs={12} md={6}>
+              <InputLabel htmlFor="username" className={label}>
+                Username
+              </InputLabel>
+              <TextField
+                id="username"
+                fullWidth
+                margin="normal"
+                InputProps={{
+                  classes: { input: inputs },
+                  disableUnderline: true,
+                }}
+                name="username"
+                autoComplete="username"
+                placeholder="Username"
+                autoFocus
+                helperText={touched.username ? errors.username : ''}
+                error={touched.username && Boolean(errors.username)}
+                value={values.username}
+                onChange={handleChange}
+              />
+              <InputLabel htmlFor="email" className={label}>
+                Email
+              </InputLabel>
+              <TextField
+                id="email"
+                fullWidth
+                margin="normal"
+                InputProps={{
+                  classes: { input: inputs },
+                  disableUnderline: true,
+                }}
+                name="email"
+                autoComplete="email"
+                placeholder="email@domain.com"
+                helperText={touched.email ? errors.email : ''}
+                error={touched.email && Boolean(errors.email)}
+                value={values.email}
+                onChange={handleChange}
+              />
+            </Grid>
+            <Grid item xs={12} md={6}>
+              <InputLabel htmlFor="password" className={label}>
+                Password
+              </InputLabel>
+              <TextField
+                id="password"
+                fullWidth
+                margin="normal"
+                InputProps={{
+                  classes: { input: inputs },
+                  disableUnderline: true,
+                }}
+                type="password"
+                autoComplete="current-password"
+                placeholder="Password"
+                helperText={touched.password ? errors.password : ''}
+                error={touched.password && Boolean(errors.password)}
+                value={values.password}
+                onChange={handleChange}
+              />
 
+              <InputLabel htmlFor="confirmPassword" className={label}>
+                confrim password
+              </InputLabel>
+              <TextField
+                id="confirmPassword"
+                fullWidth
+                margin="normal"
+                InputProps={{
+                  classes: { input: inputs },
+                  disableUnderline: true,
+                }}
+                type="password"
+                placeholder="Confirm password"
+                helperText={touched.confirmPassword ? errors.confirmPassword : ''}
+                error={touched.confirmPassword && Boolean(errors.confirmPassword)}
+                value={values.confirmPassword}
+                onChange={handleChange}
+              />
+            </Grid>
+            <Box alignItems="center" justifyContent="center" display="flex" width="100%">
+              <ButtonGroup disableElevation variant="contained">
+                <Button
+                  className={roleButton}
+                  disabled={!role}
+                  onClick={() => {
+                    setFieldValue('role', handleRoleButton());
+                  }}
+                >
+                  Owner
+                </Button>
+                <Button
+                  className={roleButton}
+                  disabled={role}
+                  onClick={() => {
+                    setFieldValue('role', handleRoleButton());
+                  }}
+                >
+                  Sitter
+                </Button>
+              </ButtonGroup>
+              <input type="hidden" name="role" id="role" />
+            </Box>
+          </Grid>
           <Box textAlign="center">
-            <Button type="submit" size="large" variant="contained" color="primary" className={classes.submit}>
-              {isSubmitting ? <CircularProgress style={{ color: 'white' }} /> : 'Create'}
+            <Button type="submit" size="large" variant="contained" color="primary" className={submit}>
+              {isSubmitting ? <CircularProgress className={circularProgress} /> : 'Sign up'}
             </Button>
+          </Box>
+          <Box textAlign="center">
+            <Typography className={caption}>
+              Already a member? &nbsp;
+              <Link className={link} to="/login">
+                Login
+              </Link>
+            </Typography>
           </Box>
         </form>
       )}

--- a/client/src/pages/SignUp/SignUpForm/useStyles.ts
+++ b/client/src/pages/SignUp/SignUpForm/useStyles.ts
@@ -1,34 +1,69 @@
+import { alpha } from '@material-ui/core';
 import { makeStyles } from '@material-ui/core/styles';
 
 const useStyles = makeStyles((theme) => ({
   form: {
-    width: '100%', // Fix IE 11 issue.
+    width: '100%',
     marginTop: theme.spacing(1),
+    paddingTop: theme.spacing(4),
+    '& .MuiFormControl-root': {
+      marginTop: theme.spacing(1),
+    },
+  },
+  caption: {
+    fontWeight: 'bold',
+  },
+  link: {
+    textDecoration: 'none',
+    color: theme.palette.primary.main,
   },
   label: {
-    fontSize: 19,
-    color: 'rgb(0,0,0,0.4)',
-    paddingLeft: '5px',
+    fontWeight: 800,
+    fontSize: 12,
+    color: theme.palette.common.black,
+    textTransform: 'uppercase',
+    marginTop: theme.spacing(1),
   },
   inputs: {
-    marginTop: '.8rem',
-    height: '2rem',
-    padding: '5px',
-  },
-  forgot: {
-    paddingRight: 10,
-    color: '#3a8dff',
+    borderRadius: 4,
+    position: 'relative',
+    backgroundColor: theme.palette.common.white,
+    border: '1px solid #ced4da',
+    fontSize: 16,
+    width: '80%',
+    height: '100%',
+    padding: theme.spacing(2),
+    transition: theme.transitions.create(['border-color', 'box-shadow']),
+    '&:focus': {
+      boxShadow: `${alpha(theme.palette.primary.main, 0.25)} 0 0 0 0.2rem`,
+      borderColor: theme.palette.primary.main,
+    },
   },
   submit: {
-    margin: theme.spacing(3, 2, 2),
-    padding: 10,
+    textTransform: 'uppercase',
+    margin: theme.spacing(6, 2, 2),
+    padding: theme.spacing(1),
     width: 160,
     height: 56,
+    backgroundColor: theme.palette.primary.main,
     borderRadius: theme.shape.borderRadius,
-    marginTop: 49,
-    fontSize: 16,
-    backgroundColor: '#3a8dff',
-    fontWeight: 'bold',
+    fontSize: 12,
+    fontWeight: 600,
+  },
+  roleButton: {
+    marginTop: theme.spacing(2),
+    border: 1,
+    borderStyle: 'solid',
+    borderColor: theme.palette.primary.main,
+    background: theme.palette.primary.main,
+    color: theme.palette.common.white,
+    '&.Mui-disabled': {
+      color: theme.palette.primary.main,
+      background: 'transparent',
+    },
+  },
+  circularProgress: {
+    color: theme.palette.common.white,
   },
 }));
 

--- a/client/src/pages/SignUp/useStyles.ts
+++ b/client/src/pages/SignUp/useStyles.ts
@@ -1,26 +1,22 @@
 import { makeStyles } from '@material-ui/core/styles';
 
-const useStyles = makeStyles(() => ({
+const useStyles = makeStyles((theme) => ({
   root: {
     minHeight: '100vh',
     '& .MuiInput-underline:before': {
       borderBottom: '1.2px solid rgba(0, 0, 0, 0.2)',
     },
-  },
-  authWrapper: {
-    display: 'flex',
-    alignItems: 'flex-start',
-    justifyContent: 'space-between',
-    flexDirection: 'column',
-    minHeight: '100vh',
-    paddingTop: 23,
+    alignContent: 'center',
+    justifyContent: 'center',
+    paddingTop: theme.spacing(10),
   },
   welcome: {
     fontSize: 26,
     paddingBottom: 20,
-    color: '#000000',
+    color: theme.palette.common.black,
     fontWeight: 700,
-    fontFamily: "'Open Sans'",
+    textAlign: 'center',
+    width: '95%',
   },
 }));
 

--- a/client/src/themes/theme.ts
+++ b/client/src/themes/theme.ts
@@ -1,6 +1,7 @@
-import { createMuiTheme } from '@material-ui/core';
+import { createTheme } from '@material-ui/core';
 
-export const theme = createMuiTheme({
+export const theme = createTheme({
+  spacing: 8,
   typography: {
     fontFamily: '"Open Sans", "sans-serif", "Roboto"',
     fontSize: 12,
@@ -10,7 +11,8 @@ export const theme = createMuiTheme({
     },
   },
   palette: {
-    primary: { main: '#3A8DFF' },
+    primary: { main: '#f04040' },
+    success: { main: '#32CD32' },
   },
   shape: {
     borderRadius: 5,


### PR DESCRIPTION
### What this PR does :
- Create a **demo user** functionality that will be used later to allow recruiters and managers to easily test the app's features without having to sign up
- Add an `Owner`|`Sitter` to sign in as a demo user (**Owner**|**Sitter**) with a hardcoded username and password

### Screenshots / Videos:
>Sign in
>![signiIn Demo](https://user-images.githubusercontent.com/32603079/138186451-f0c9777a-5389-43ed-a7d2-8df80934bcc9.PNG)

>Signup
>![signup demo](https://user-images.githubusercontent.com/32603079/138186469-9f890248-8232-490d-aa0c-9c9dbe71ef32.PNG)

> Test the functionality with temporary data  > `Signup` page
>![VideoDemoSignup](https://user-images.githubusercontent.com/32603079/138186560-b16cb033-4c68-4d95-90f0-7cde8bc2c73d.gif)
 
### Information needed to test this feature :
- Use the data stored in. [..\...\useDemoCredentials.ts](https://github.com/hatchways/team-dumplings/blob/FE_Demo_User_%2318/client/src/components/DemoUser/useDemoCredentials.ts)
to register `demoSitter` && `demoOwner`
- Browse to **Sign in** or **Signup** page, scroll down to the `Sign in as a demo user`   under the login button, and select either sitter or owner to test the accessibility 

### Issues with the current functionality :
- Even we are still in dev env, hardcoded credentials on the client-side may it pose a problem if the data are exposed,
- Animated showcase after the demo authentication will be more convenient

### Features:
- [x] #18 
- [ ] Separate "Demo" branch with dummy content 🧪 
